### PR TITLE
Remove pull_request trigger

### DIFF
--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -1,5 +1,5 @@
 name: Main workflow
-on: [push, pull_request]
+on: push
 jobs:
   run:
     name: Compile


### PR DESCRIPTION
Push already triggers pull_requests. If defined explicitly, runs workflow twice.